### PR TITLE
Add dist server to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist-server/*

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+// Changed on jan 5
+var express = require('express');
+
+var app = express();
+app.get('/', function (req, res) {
+  res.send('hello world');
+});
+var port = process.env.PORT || 3000;
+app.listen(3000, function () {
+  return console.log("Listening to port ".concat(port));
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon src/index.js",
-    "babel": "./node_modules/.bin/babel"
+    "babel": "./node_modules/.bin/babel",
+    "transpile": "babel src --out-dir dist-server"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Intro/Description

- Dist-server is the transpiled file created after running babel. It does not need to be uploaded as it is created during the production.

## Any new library or package needed?

-No

## Any thing else to consider ?

-No